### PR TITLE
Switch the standard to C89

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(finalfusion_ffi)
 
 enable_testing()
 
-set(CMAKE_C_FLAGS "-Wall -Werror -Wpedantic -std=c11")
+set(CMAKE_C_FLAGS "-Wall -Werror -Wpedantic -std=c89")
 
 add_subdirectory(finalfusion-ffi)
 add_subdirectory(tests)

--- a/include/finalfusion.h
+++ b/include/finalfusion.h
@@ -30,4 +30,4 @@ typedef struct ff_embeddings_t *ff_embeddings;
 }
 #endif
 
-#endif // FINALFUSION_H
+#endif /* FINALFUSION_H */


### PR DESCRIPTION
C99 is not fully supported by Visual C++ and we probably want to at
least keep open the possibility of native Windows builds.