### PR TITLE
Add mmap method to API.

### DIFF
--- a/include/finalfusion.h
+++ b/include/finalfusion.h
@@ -23,6 +23,12 @@ typedef struct ff_embeddings_t *ff_embeddings;
   ff_embeddings ff_read_embeddings(char const *filename);
 
   /**
+   * Mmap finalfusion embeddings. Returns a pointer to the embeddings
+   * when successful or NULL otherwise.
+   */
+  ff_embeddings ff_mmap_embeddings(char const *filename);
+
+  /**
    * Free finalfusion embeddings.
    */
   void ff_free_embeddings(ff_embeddings embeddings);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,3 +10,7 @@ add_test(read_nonexistent_returns_null read_nonexistent_returns_null)
 add_executable(embedding_lookup embedding_lookup.c)
 target_link_libraries(embedding_lookup finalfusion)
 add_test(embedding_lookup embedding_lookup)
+
+add_executable(mmap_embeddings mmap_embeddings.c)
+target_link_libraries(mmap_embeddings finalfusion)
+add_test(mmap_embeddings mmap_embeddings)

--- a/tests/mmap_embeddings.c
+++ b/tests/mmap_embeddings.c
@@ -1,0 +1,30 @@
+#include <stdlib.h>
+
+#include "finalfusion.h"
+
+int main() {
+  float *embedding;
+  ff_embeddings embeds = ff_mmap_embeddings("foo");
+  if (embeds != NULL) {
+    return 1;
+  }
+
+  embeds = ff_mmap_embeddings("data/test.fifu");
+
+  /* in vocab*/
+  embedding = ff_embedding_lookup(embeds, "Berlin");
+  if (embedding == NULL) {
+    return 1;
+  }
+  free(embedding);
+
+  /* oov */
+  embedding = ff_embedding_lookup(embeds, "Tübingen");
+  if (embedding != NULL) {
+    return 1;
+  }
+  free(embedding);
+
+  ff_free_embeddings(embeds);
+  return 0;
+}


### PR DESCRIPTION
Adds a `ff_mmap_embeddings` method as well as a convenience method in Rust to both read and mmap embeddings.

It looks like we're importing something unix specific to get `OsStr::from_bytes`:
`use std::os::unix::ffi::OsStrExt;`.

There is `to_string_lossy` on `CStr` which could replace `from_bytes`, but that would assume that all paths are utf8, else parts are dropped. 

Another option should be platform specific methods:
```Rust
#[cfg(windows)]
fn cstr_to_path(*const char path) -> OsStr {...}

#[cfg(unix)]
fn cstr_to_path(*const char path) -> OsStr {...}
```