### PR TITLE
Compile a static library version of libfinalfusion-ffi

### DIFF
--- a/finalfusion-ffi/CMakeLists.txt
+++ b/finalfusion-ffi/CMakeLists.txt
@@ -6,18 +6,26 @@ else()
     set(TARGET_DIR "release")
 endif()
 
-set(LIB_FILE "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/libfinalfusion.so")
-
 file(GLOB_RECURSE LIB_SOURCES "*.rs")
 
+set(SHARED_LIB_FILE "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/libfinalfusion.so")
+set(STATIC_LIB_FILE "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/libfinalfusion.a")
+
 add_custom_command(
-    OUTPUT ${LIB_FILE}
+    OUTPUT ${SHARED_LIB_FILE} ${STATIC_LIB_FILE}
     COMMENT "Compiling finalfusion library"
     COMMAND CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} ${CARGO_CMD} 
     DEPENDS ${LIB_SOURCES}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_custom_target(finalfusion_target ALL DEPENDS ${LIB_FILE})
+# Dynamic library
+add_custom_target(finalfusion_target ALL DEPENDS ${SHARED_LIB_FILE})
 add_library(finalfusion SHARED IMPORTED GLOBAL)
 add_dependencies(finalfusion finalfusion_target)
-set_target_properties(finalfusion PROPERTIES IMPORTED_LOCATION ${LIB_FILE})
+set_target_properties(finalfusion PROPERTIES IMPORTED_LOCATION ${SHARED_LIB_FILE})
+
+# Static library
+add_custom_target(finalfusion_static_target ALL DEPENDS ${STATIC_LIB_FILE})
+add_library(finalfusion_static STATIC IMPORTED GLOBAL)
+add_dependencies(finalfusion_static finalfusion_static_target)
+set_target_properties(finalfusion_static PROPERTIES IMPORTED_LOCATION ${STATIC_LIB_FILE})

--- a/finalfusion-ffi/Cargo.toml
+++ b/finalfusion-ffi/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [lib]
 name = "finalfusion"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
 finalfusion = "0.8"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,3 +14,9 @@ add_test(embedding_lookup embedding_lookup)
 add_executable(mmap_embeddings mmap_embeddings.c)
 target_link_libraries(mmap_embeddings finalfusion)
 add_test(mmap_embeddings mmap_embeddings)
+
+# Ensure that static linking works
+add_executable(embedding_lookup_static embedding_lookup.c)
+# In the future: collect dynamic library dependencies from Cargo.
+target_link_libraries(embedding_lookup_static finalfusion_static dl m pthread)
+add_test(embedding_lookup_static embedding_lookup_static)


### PR DESCRIPTION
This static library version can be used by `libfinalfusion_cxx` to link against libfinalfusion without the shared library dependency.