### PR TITLE
Propagate includes for libfinalfusion.

### DIFF
--- a/finalfusion-ffi/CMakeLists.txt
+++ b/finalfusion-ffi/CMakeLists.txt
@@ -22,10 +22,14 @@ add_custom_command(
 add_custom_target(finalfusion_target ALL DEPENDS ${SHARED_LIB_FILE})
 add_library(finalfusion SHARED IMPORTED GLOBAL)
 add_dependencies(finalfusion finalfusion_target)
-set_target_properties(finalfusion PROPERTIES IMPORTED_LOCATION ${SHARED_LIB_FILE})
+set_target_properties(finalfusion PROPERTIES
+        IMPORTED_LOCATION ${SHARED_LIB_FILE}
+        INTERFACE_INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/include)
 
 # Static library
 add_custom_target(finalfusion_static_target ALL DEPENDS ${STATIC_LIB_FILE})
 add_library(finalfusion_static STATIC IMPORTED GLOBAL)
 add_dependencies(finalfusion_static finalfusion_static_target)
-set_target_properties(finalfusion_static PROPERTIES IMPORTED_LOCATION ${STATIC_LIB_FILE})
+set_target_properties(finalfusion_static PROPERTIES
+        IMPORTED_LOCATION ${STATIC_LIB_FILE}
+        INTERFACE_INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/include)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,5 @@
 include(CTest)
 
-include_directories ("${PROJECT_SOURCE_DIR}/include")
 file(COPY testdata/test.fifu DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/data)
 
 add_executable(read_nonexistent_returns_null read_nonexistent_returns_null.c)


### PR DESCRIPTION
This makes it easier to include `finalfusion.h` for projects with dependencies on libfinalfusion.