### PR TITLE
Update finalfusion dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   include:
   - language: rust
     os: linux
-    rust: 1.31.0
+    rust: 1.32.0
   - language: rust
     os: linux
     rust: stable

--- a/finalfusion-ffi/Cargo.toml
+++ b/finalfusion-ffi/Cargo.toml
@@ -9,7 +9,7 @@ name = "finalfusion"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-finalfusion = "0.8"
+finalfusion = "0.10"
 
 [profile.dev]
 panic = "abort"


### PR DESCRIPTION
Upping the finalfusion dependency gives us support to mmap quantized embeddings.