### PR TITLE
Add interface to vocab.

### DIFF
--- a/finalfusion-ffi/src/lib.rs
+++ b/finalfusion-ffi/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod embeddings;
+pub mod vocab;
 
 use std::cell::RefCell;
 use std::ffi::CString;

--- a/finalfusion-ffi/src/vocab.rs
+++ b/finalfusion-ffi/src/vocab.rs
@@ -1,0 +1,74 @@
+use std::ffi::CStr;
+use std::mem;
+use std::os::raw::{c_char, c_int};
+
+use finalfusion::chunks::vocab::WordIndex;
+use finalfusion::prelude::*;
+
+use crate::check_null;
+
+/// Indices lookup.
+///
+/// Returns an integer indicating how a word is represented:
+///    * 0 if the word cannot be represented
+///    * `n` if the word is represented by `n` embeddings
+///
+/// Writes the indices to `indices_res` if it is not a null-pointer.
+#[no_mangle]
+pub unsafe extern "C" fn ff_vocab_indices(
+    embeddings: *mut Embeddings<VocabWrap, StorageWrap>,
+    word: *const c_char,
+    indices_res: *mut *mut usize,
+) -> c_int {
+    check_null!(embeddings);
+    check_null!(word);
+    let embeddings = &*embeddings;
+    let vocab = embeddings.vocab();
+    let word = CStr::from_ptr(word).to_string_lossy();
+    let idx = if let Some(idx) = vocab.idx(&word) {
+        idx
+    } else {
+        return 0;
+    };
+    let mut indices = match idx {
+        WordIndex::Word(idx) => {
+            if indices_res.is_null() {
+                return 1;
+            }
+            vec![idx]
+        }
+        WordIndex::Subword(indices) => {
+            if indices_res.is_null() {
+                return indices.len() as c_int;
+            }
+            indices
+        }
+    };
+    let len = indices.len() as c_int;
+    if !indices_res.is_null() {
+        let ptr = indices.as_mut_ptr();
+        mem::forget(indices);
+        *indices_res = ptr;
+    }
+    len
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ff_vocab_len(
+    embeddings: *mut Embeddings<VocabWrap, StorageWrap>,
+) -> usize {
+    check_null!(embeddings);
+    let embeddings = &*embeddings;
+    let vocab = embeddings.vocab();
+    vocab.vocab_len()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ff_words_len(
+    embeddings: *mut Embeddings<VocabWrap, StorageWrap>,
+) -> usize {
+    check_null!(embeddings);
+    let embeddings = &*embeddings;
+    let vocab = embeddings.vocab();
+    vocab.words_len()
+}

--- a/include/finalfusion.h
+++ b/include/finalfusion.h
@@ -77,6 +77,25 @@ typedef struct ff_embeddings_t *ff_embeddings;
    */
   float *ff_embedding_lookup(ff_embeddings embeddings, char const *word);
 
+  /**
+   * Look up the indices of a word.
+   *
+   * Return 0 if the word cannot be looked up and n if it is represented by n indices.
+   *
+   * Returns a buffer holding the indices if a non-null pointer is passed as indices.
+   */
+  int ff_vocab_indices(ff_embeddings embeddings, char const *word, size_t **indices);
+
+  /**
+   * Return the total length of the vocabulary, including potential subword embeddings.
+   */
+  size_t ff_vocab_len(ff_embeddings embeddings);
+
+  /**
+   * Return the number of in-vocabulary words.
+   */
+  size_t ff_words_len(ff_embeddings embeddings);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,10 @@ add_executable(write_embeddings write_embeddings.c)
 target_link_libraries(write_embeddings finalfusion)
 add_test(write_embeddings write_embeddings)
 
+add_executable(vocab_test vocab_test.c)
+target_link_libraries(vocab_test finalfusion)
+add_test(vocab_test vocab_test)
+
 # Ensure that static linking works
 add_executable(embedding_lookup_static embedding_lookup.c)
 # In the future: collect dynamic library dependencies from Cargo.

--- a/tests/vocab_test.c
+++ b/tests/vocab_test.c
@@ -1,0 +1,37 @@
+#include <stdlib.h>
+
+#include <finalfusion.h>
+
+int main() {
+  int n;
+  size_t* indices;
+
+  ff_embeddings embeds = ff_read_embeddings("testdata/test.fifu");
+  if (embeds == NULL) {
+    return 1;
+  }
+
+  n = ff_vocab_indices(embeds, "Berlin", &indices);
+
+  if (n != 1) {
+    return 1;
+  }
+
+  if (*indices != 0) {
+    return 1;
+  }
+  free(indices);
+
+  if (ff_vocab_len(embeds) != 41) {
+    return 1;
+  }
+
+  if (ff_words_len(embeds) != 41) {
+    return 1;
+  }
+
+
+  ff_free_embeddings(embeds);
+
+  return 0;
+}


### PR DESCRIPTION
I don't think we should expose `VocabWrap` directly in the FFI. If we restrict the API to going through `Embeddings`, we can make sure that the vocab methods don't get used after `Embeddings` is freeed. 

#18 should probably go in first.

Fixes #15 