### PR TITLE
Matrix copy

### DIFF
--- a/finalfusion-ffi/Cargo.lock
+++ b/finalfusion-ffi/Cargo.lock
@@ -99,6 +99,7 @@ name = "finalfusion-ffi"
 version = "0.1.0"
 dependencies = [
  "finalfusion 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ndarray 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/finalfusion-ffi/Cargo.toml
+++ b/finalfusion-ffi/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
 finalfusion = "0.10"
+ndarray = "0.12"
 
 [profile.dev]
 panic = "abort"

--- a/finalfusion-ffi/src/lib.rs
+++ b/finalfusion-ffi/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod embeddings;
+pub mod storage;
 pub mod vocab;
 
 use std::cell::RefCell;

--- a/finalfusion-ffi/src/storage.rs
+++ b/finalfusion-ffi/src/storage.rs
@@ -1,0 +1,51 @@
+use std::mem;
+
+use finalfusion::prelude::*;
+use ndarray::Array2;
+
+use crate::check_null;
+
+/// Return the numer of rows in the embedding matrix.
+#[no_mangle]
+pub unsafe extern "C" fn ff_storage_rows(
+    embeddings: *const Embeddings<VocabWrap, StorageWrap>,
+) -> usize {
+    check_null!(embeddings);
+    let embeddings = &*embeddings;
+    embeddings.storage().shape().0
+}
+
+/// Copy the entire embedding matrix.
+#[no_mangle]
+pub unsafe extern "C" fn ff_storage_copy(
+    embeddings: *const Embeddings<VocabWrap, StorageWrap>,
+) -> *mut f32 {
+    check_null!(embeddings);
+    let embeddings = &*embeddings;
+    let array = match embeddings.storage() {
+        StorageWrap::MmapArray(mmap) => mmap.view().to_owned(),
+        StorageWrap::NdArray(array) => array.0.clone(),
+        StorageWrap::QuantizedArray(quantized) => copy_storage_to_array(quantized.as_ref()),
+        StorageWrap::MmapQuantizedArray(quantized) => copy_storage_to_array(quantized),
+    };
+    let mut v = array.into_raw_vec();
+    let ptr = v.as_mut_ptr();
+    mem::forget(v);
+    ptr
+}
+
+/// Copy storage to an array.
+///
+/// This should only be used for storage types that do not provide
+/// an ndarray view that can be copied trivially, such as quantized
+/// storage.
+fn copy_storage_to_array(storage: &dyn Storage) -> Array2<f32> {
+    let (rows, dims) = storage.shape();
+
+    let mut array = Array2::<f32>::zeros((rows, dims));
+    for idx in 0..rows {
+        array.row_mut(idx).assign(&storage.embedding(idx).as_view());
+    }
+
+    array
+}

--- a/include/finalfusion.h
+++ b/include/finalfusion.h
@@ -96,6 +96,18 @@ typedef struct ff_embeddings_t *ff_embeddings;
    */
   size_t ff_words_len(ff_embeddings embeddings);
 
+  /**
+   * Get a copy of the embedding matrix.
+   *
+   * Returns the embedding matrix as a float array.
+   */
+  float *ff_storage_copy(ff_embeddings embeddings);
+
+  /**
+   * Get the number of rows in the embedding matrix.
+   */
+  int ff_storage_rows(ff_embeddings embeddings);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,3 +39,7 @@ add_executable(embedding_lookup_static embedding_lookup.c)
 # In the future: collect dynamic library dependencies from Cargo.
 target_link_libraries(embedding_lookup_static finalfusion_static dl m pthread)
 add_test(embedding_lookup_static embedding_lookup_static)
+
+add_executable(matrix_copy matrix_copy.c)
+target_link_libraries(matrix_copy finalfusion)
+add_test(matrix_copy matrix_copy)

--- a/tests/matrix_copy.c
+++ b/tests/matrix_copy.c
@@ -1,0 +1,50 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include <finalfusion.h>
+
+int main() {
+  float *embedding;
+  float *matrix_copy;
+  float *embedding_from_copy;
+  int i;
+  size_t dims;
+  ff_embeddings embeds = ff_read_embeddings("testdata/test.fifu");
+  if (embeds == NULL) {
+    return 1;
+  }
+  dims = ff_embeddings_dims(embeds);
+
+  if (ff_storage_rows(embeds) != 41) {
+    return 1;
+  }
+
+  matrix_copy = ff_storage_copy(embeds);
+  if (matrix_copy == NULL) {
+    return 1;
+  }
+
+  embedding_from_copy = malloc(dims * sizeof(float));
+  if (embedding_from_copy) {
+    memcpy(embedding_from_copy, matrix_copy, dims * sizeof(float));
+  } else {
+    return 1;
+  }
+
+  /* in vocab*/
+  embedding = ff_embedding_lookup(embeds, "Berlin");
+  if (embedding == NULL) {
+    return 1;
+  }
+  for (i = 0; i < dims; ++i) {
+    if (*(embedding + i) != *(embedding_from_copy + i)) {
+      return 1;
+    }
+  }
+  free(embedding_from_copy);
+  free(embedding);
+  free(matrix_copy);
+
+  ff_free_embeddings(embeds);
+  return 0;
+}


### PR DESCRIPTION
Not quite #17 but still something that might be nice to have. Mirrors the implementation in `finalfusion-python`, where I stole the `copy_storage_to_array` fn from.
